### PR TITLE
Update bounds on ghc-exactprint, reimplement overlap check

### DIFF
--- a/apply-refact.cabal
+++ b/apply-refact.cabal
@@ -27,7 +27,7 @@ library
   GHC-Options: -Wall
   build-depends: base >=4.7 && <4.9
                , refact >= 0.2
-               , ghc-exactprint >= 0.3
+               , ghc-exactprint >= 0.4.1
                , ghc
                , containers
                , syb
@@ -44,7 +44,7 @@ executable refactor
   ghc-options: -Wall -fno-warn-unused-do-bind
   build-depends: base >= 4.7 && < 4.9
                , refact >= 0.2
-               , ghc-exactprint >= 0.3.1
+               , ghc-exactprint >= 0.4.1
                , ghc
                , containers
                , syb
@@ -70,7 +70,7 @@ Test-Suite test
                      , tasty-golden
                      , base < 5
                , refact >= 0.2
-               , ghc-exactprint >= 0.3
+               , ghc-exactprint >= 0.4.1
                , ghc
                , containers
                , syb

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -211,7 +211,7 @@ runPipe Options{..} file = do
                    else return . flip evalState 0 $
                           foldM (uncurry runRefactoring) (as, m) (concatMap snd filtRefacts)
   when (optionsDebug) (putStrLn (showAnnData ares 0 res))
-  let output = exactPrintWithAnns res ares
+  let output = exactPrint res ares
   if optionsInplace && isJust optionsTarget
     then writeFile file output
     else case optionsOutput of
@@ -262,7 +262,7 @@ refactoringLoop as m hints@((hintDesc, rs): rss) =
       , ("n", LoopOption "Don't apply the current hint" (refactoringLoop as m rss))
       , ("q", LoopOption "Apply no further hints" (return (as, m)))
       , ("d", LoopOption "Discard previous changes" mzero )
-      , ("v", LoopOption "View current file" (liftIO (putStrLn (exactPrintWithAnns m as))
+      , ("v", LoopOption "View current file" (liftIO (putStrLn (exactPrint m as))
                                               >> refactoringLoop as m hints))
       , ("?", LoopOption "Show this help menu" loopHelp)]
     loopHelp = do
@@ -273,7 +273,7 @@ refactoringLoop as m hints@((hintDesc, rs): rss) =
     yAction =
       let (!r1, !r2) = flip evalState 0 $ foldM (uncurry runRefactoring) (as, m) rs
         in do
-          exactPrintWithAnns r2 r1 `seq` return ()
+          exactPrint r2 r1 `seq` return ()
           refactoringLoop r1 r2 rss
 
 

--- a/tests/examples/Monad18.hs.expected
+++ b/tests/examples/Monad18.hs.expected
@@ -1,1 +1,1 @@
-folder f a xs = foldM_ f a xs >> return ()
+folder f a xs = Control.Monad.void (foldM f a xs)

--- a/tests/examples/Sequence.hs.expected
+++ b/tests/examples/Sequence.hs.expected
@@ -3,7 +3,7 @@
 -- data structures or a state-transforming monad.
 mapAndUnzipM      :: (Monad m) => (a -> m (b,c)) -> [a] -> m ([b], [c])
 {-# INLINE mapAndUnzipM #-}
-mapAndUnzipM f xs =  mapM f xs >>= return . foo
+mapAndUnzipM f xs =  Control.Monad.liftM foo (sequence (map f xs))
 
 ren = run (foo) run
 


### PR DESCRIPTION
Bumped the bounds so apply-refact compiles with newest ghc-exactprint.

Also, the overlap check had a bug. Consider the following two ideas given by hlint:

```
(S1, [R1, D1])
(S2, [R2, D2])
```

(where Sn = idea message, Rn = a Replace constructor, Dn = a Delete constructor)

If R1 overlapped with R2 or D2, it would previously get filtered out, leaving [D1, R2, D2]... essentially only half of idea 1 would get implemented, and code would break. I reimplemented it to consider all the refactorings of a given idea as a unit.