### PR TITLE
Relax bounds on GHC

### DIFF
--- a/apply-refact.cabal
+++ b/apply-refact.cabal
@@ -33,7 +33,7 @@ library
   build-depends: base >=4.8 && <4.10
                , refact >= 0.2
                , ghc-exactprint >= 0.5.2
-               , ghc >= 8.0.1 && < 8.2
+               , ghc >= 8.0.1 && < 8.1
                , containers
                , syb
                , mtl
@@ -54,7 +54,7 @@ executable refactor
   build-depends: base >= 4.8 && < 4.10
                , refact >= 0.2
                , ghc-exactprint >= 0.5.2
-               , ghc >= 8.0.1 && < 8.2
+               , ghc >= 8.0.1 && < 8.1
                , containers
                , syb
                , mtl
@@ -81,7 +81,7 @@ Test-Suite test
                      , base < 5
                , refact >= 0.2
                , ghc-exactprint >= 0.5.2
-               , ghc >= 8.0.1 && < 8.2
+               , ghc >= 8.0.1 && < 8.1
                , containers
                , syb
                , mtl

--- a/apply-refact.cabal
+++ b/apply-refact.cabal
@@ -33,7 +33,7 @@ library
   build-depends: base >=4.8 && <4.10
                , refact >= 0.2
                , ghc-exactprint >= 0.5.2
-               , ghc == 8.0.1
+               , ghc >= 8.0.1 && < 8.2
                , containers
                , syb
                , mtl
@@ -54,7 +54,7 @@ executable refactor
   build-depends: base >= 4.8 && < 4.10
                , refact >= 0.2
                , ghc-exactprint >= 0.5.2
-               , ghc == 8.0.1
+               , ghc >= 8.0.1 && < 8.2
                , containers
                , syb
                , mtl
@@ -81,7 +81,7 @@ Test-Suite test
                      , base < 5
                , refact >= 0.2
                , ghc-exactprint >= 0.5.2
-               , ghc  == 8.0.1
+               , ghc >= 8.0.1 && < 8.2
                , containers
                , syb
                , mtl


### PR DESCRIPTION
Equality bounds on GHC force me to have local changes to this package when I have a custom built GHC. My version looks like this: `8.0.1.20160729`. I don't think there's much harm in relaxing.