### PR TITLE
Import SourceText(..) for GHC 8.2

### DIFF
--- a/src/Refact/Fixity.hs
+++ b/src/Refact/Fixity.hs
@@ -6,7 +6,7 @@ module Refact.Fixity (applyFixities) where
 import SrcLoc
 
 import Refact.Utils
-import BasicTypes (Fixity(..), defaultFixity, compareFixity, negateFixity, FixityDirection(..))
+import BasicTypes (Fixity(..), defaultFixity, compareFixity, negateFixity, FixityDirection(..), SourceText(..))
 import HsExpr
 import RdrName
 import OccName


### PR DESCRIPTION
When trying to build with GHC 8.2 I got an error about
this import missing.

I'm not sure if it worked for you after 84335c5e4a54ff381d8a0596e294491eeda6b84c and something changed with GHC.