### PR TITLE
Stop depending on the temporary package

### DIFF
--- a/apply-refact.cabal
+++ b/apply-refact.cabal
@@ -12,7 +12,7 @@ maintainer:          matthewtpickering@gmail.com
 -- copyright:
 category:            Development
 build-type:          Simple
-extra-source-files: CHANGELOG
+extra-source-files:  CHANGELOG
                    , README.md
                    , tests/examples/*.hs
                    , tests/examples/*.hs.refact
@@ -40,7 +40,6 @@ library
                , mtl
                , process
                , transformers
-               , temporary
                , filemanip
                , unix-compat
                , directory
@@ -73,7 +72,6 @@ executable refactor
                , filemanip
                , unix-compat
                , filepath
-               , temporary
                , transformers
 
 Test-Suite test
@@ -109,5 +107,4 @@ Test-Suite test
                , unix-compat
                , filepath
                , silently
-               , temporary
                , transformers

--- a/src/Refact/Run.hs
+++ b/src/Refact/Run.hs
@@ -45,7 +45,6 @@ import Data.Maybe
 import Data.Version
 import Options.Applicative
 import System.IO.Extra
-import System.IO.Temp
 import System.FilePath.Find
 import System.Exit
 import qualified System.PosixCompat.Files as F
@@ -63,9 +62,9 @@ refactMain = do
     (error "Must specify either the target file or the refact file")
   case optionsTarget of
     Nothing ->
-      withSystemTempFile "stdin"  (\fp hin -> do
-        getContents >>= hPutStrLn hin >> hClose hin
-        runPipe o fp)
+      withTempFile $ \fp -> do
+        getContents >>= writeFileUTF8 fp
+        runPipe o fp
     Just target -> do
       targetStatus <- F.getFileStatus target
       if F.isDirectory targetStatus

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -19,7 +19,7 @@ import Test.Tasty.ExpectedFailure
 
 
 main =
-  defaultMain =<< mkTests <$> findTests
+  defaultMain . mkTests =<< findTests
 
 testDir = "tests/examples"
 
@@ -55,6 +55,3 @@ mkTests files = testGroup "Unit tests" (map mkTest files)
           diffCmd = \ref new -> ["diff", "-u", ref, new]
           testFn  = if fp `elem` expectedFailures then expectFail else id
       in testFn $ goldenVsFileDiff fp diffCmd (fp <.> "expected") outfile action
-
-
-


### PR DESCRIPTION
I pulled in the `extra` package in #65, which covers what the `temporary` package provides, so the latter is no longer needed.