### PR TITLE
Remove some exported functions from Refact.Apply which are only used in runPipe

### DIFF
--- a/apply-refact.cabal
+++ b/apply-refact.cabal
@@ -53,8 +53,8 @@ executable refactor
                  Refact.Apply
                  Refact.Fixity
                  Refact.Internal
-                 Refact.Utils
                  Refact.Run
+                 Refact.Utils
   autogen-modules:
                  Paths_apply_refact
   hs-source-dirs:      src
@@ -82,10 +82,10 @@ Test-Suite test
   main-is:             Test.hs
   other-modules:
                  Paths_apply_refact
-                 Refact.Run
                  Refact.Apply
                  Refact.Fixity
                  Refact.Internal
+                 Refact.Run
                  Refact.Utils
   GHC-Options:         -threaded
   Default-language:    Haskell2010

--- a/src/Refact/Apply.hs
+++ b/src/Refact/Apply.hs
@@ -3,15 +3,6 @@
 module Refact.Apply
   ( runRefactoring
   , applyRefactorings
-
-  -- * Support for runPipe in the main process
-  , Verbosity(..)
-  , rigidLayout
-  , removeOverlap
-  , refactOptions
-  , type Errors
-  , onError
-  , mkErr
   ) where
 
 import Refact.Internal

--- a/src/Refact/Run.hs
+++ b/src/Refact/Run.hs
@@ -21,9 +21,8 @@ import Language.Haskell.GHC.ExactPrint.Utils
 
 import qualified Refact.Types as R
 import Refact.Types hiding (SrcSpan)
-import Refact.Apply
 import Refact.Fixity
-import Refact.Internal (apply)
+import Refact.Internal (Errors, Verbosity(..), apply, onError, mkErr, rigidLayout)
 
 import DynFlags
 import HeaderInfo (getOptions)

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -7,8 +7,8 @@ import System.FilePath
 
 import Options.Applicative
 
-import Refact.Run
-import Refact.Apply
+import Refact.Run (Options(..), runPipe)
+import Refact.Internal (Verbosity(..))
 
 import System.IO.Silently
 import System.IO


### PR DESCRIPTION
I think these functions were exposed in the public API not because they were useful to the library users, but because of how the codebase was structured. Now the implementation of these functions were moved to `Refact.Internal` and we can choose what to export from `Refact.Apply`, so we no longer need to export these functions.