### PR TITLE
Remove unsafePerformIO, and improve error message of findGen

### DIFF
--- a/src/Refact/Apply.hs
+++ b/src/Refact/Apply.hs
@@ -28,5 +28,5 @@ applyRefactorings
   -> IO String
 applyRefactorings optionsPos inp file = do
   (as, m) <- either (onError "apply") (uncurry applyFixities)
-              <$> parseModuleWithOptions rigidLayout file
+              =<< parseModuleWithOptions rigidLayout file
   apply optionsPos False ((mempty,) <$> inp) file Silent as m

--- a/src/Refact/Fixity.hs
+++ b/src/Refact/Fixity.hs
@@ -29,9 +29,8 @@ import Data.Tuple
 
 -- | Rearrange infix expressions to account for fixity.
 -- The set of fixities is wired in and includes all fixities in base.
-applyFixities :: Anns -> Module -> (Anns, Module)
-applyFixities as m = let (as', m') = swap $ runState (everywhereM (mkM expFix) m) as
-                     in (as', m') --error (showAnnData as 0 m ++ showAnnData as' 0 m')
+applyFixities :: Anns -> Module -> IO (Anns, Module)
+applyFixities as m = swap <$> runStateT (everywhereM (mkM expFix) m) as
 
 expFix :: LHsExpr GhcPs -> M (LHsExpr GhcPs)
 expFix (L loc (OpApp _ l op r)) =

--- a/src/Refact/Run.hs
+++ b/src/Refact/Run.hs
@@ -142,7 +142,7 @@ runPipe Options{..} file = do
   output <- if null inp then readFileUTF8' file else do
     when (verb == Loud) (traceM "Parsing module")
     (as, m) <- either (onError "runPipe") (uncurry applyFixities)
-                <$> parseModuleWithArgs optionsLanguage file
+                =<< parseModuleWithArgs optionsLanguage file
     when optionsDebug (putStrLn (showAnnData as 0 m))
     apply optionsPos optionsStep inp file verb as m
 

--- a/src/Refact/Utils.hs
+++ b/src/Refact/Utils.hs
@@ -63,7 +63,7 @@ import Unsafe.Coerce
 
 -- Types
 --
-type M a = State Anns a
+type M a = StateT Anns IO a
 
 type Module = (GHC.Located (GHC.HsModule GHC.GhcPs))
 


### PR DESCRIPTION
Change `M a` from `State Ann a` to `StateT Ann IO a`.
Also improved error message of findGen.

Old message:

```
Applying 1 hints
refactor: pat /tmp/Foo.hs:1:5
CallStack (from HasCallStack):
  error, called at src/Refact/Internal.hs:589:29 in main:Refact.Internal
```

New message:

```
Applying 1 hints
refactor: Expected type not found at the location specified in the refact file.
  Expected type: Pat (GhcPass 'Parsed)
  Location: /tmp/Foo.hs:1:5: inappropriate type
```