### PR TITLE
Set annSortKey properly for eta-reduce with local binds

### DIFF
--- a/src/Refact/Internal.hs
+++ b/src/Refact/Internal.hs
@@ -454,8 +454,12 @@ doGenReplacement m p new old
                 in fromMaybe oldAnns $ do
                       oldAnn <- snd <$> find po oldAnns'
                       annWhere <- find ((== G GHC.AnnWhere) . fst) (annsDP oldAnn)
+                      let newSortKey = fmap (setSrcSpanFile newFile) <$> annSortKey oldAnn
                       newKey <- fst <$> find pn oldAnns'
-                      pure $ Map.adjust (\ann -> ann {annsDP = annsDP ann ++ [annWhere]}) newKey oldAnns
+                      pure $ Map.adjust
+                        (\ann -> ann {annsDP = annsDP ann ++ [annWhere], annSortKey = newSortKey})
+                        newKey
+                        oldAnns
 
               -- Expand the SrcSpan of the "GRHS" entry in the new file to include the local binds
               expandGRHSLoc = \case

--- a/tests/examples/EtaReduceLocalTypeSig.hs
+++ b/tests/examples/EtaReduceLocalTypeSig.hs
@@ -1,0 +1,4 @@
+f :: String -> String
+f x = show x
+  where y :: String
+        y = "foo"

--- a/tests/examples/EtaReduceLocalTypeSig.hs.expected
+++ b/tests/examples/EtaReduceLocalTypeSig.hs.expected
@@ -1,0 +1,4 @@
+f :: String -> String
+f = show
+  where y :: String
+        y = "foo"

--- a/tests/examples/EtaReduceLocalTypeSig.hs.refact
+++ b/tests/examples/EtaReduceLocalTypeSig.hs.refact
@@ -1,0 +1,1 @@
+[("test/examples/EtaReduceLocalTypeSig.hs:2:1-12: Warning: Eta reduce\nFound:\n  f x = show x\nPerhaps:\n  f = show\n",[Replace {rtype = Decl, pos = SrcSpan {startLine = 2, startCol = 1, endLine = 2, endCol = 13}, subts = [("body",SrcSpan {startLine = 2, startCol = 7, endLine = 2, endCol = 11})], orig = "f = body"}])]


### PR DESCRIPTION
This ensures `TypeSig` is printed before the corresponding `FunBind` in the `where` block.

Fixes #94