### PR TITLE
Fix stack-based build

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2020-08-03
+resolver: lts-17.2
 
 packages:
 - .


### PR DESCRIPTION
Before the fix, `stack build` failed with:

    Error: While constructing the build plan, the following exceptions were encountered:

    In the dependencies for apply-refact-0.9.0.0:
        ghc-exactprint-0.6.3.2 from stack configuration does not match >=0.6.3.3  (latest matching version is 0.6.3.4)
        uniplate-1.6.12 from stack configuration does not match >=1.6.13  (latest matching version is 1.6.13)
    needed since apply-refact is a build target.

    Some different approaches to resolving this:

    * Set 'allow-newer: true' in /Users/yairchu/.stack/config.yaml to ignore all version constraints and build anyway.

    * Recommended action: try adding the following to your extra-deps in /Users/yairchu/dev/src/apply-refact/stack.yaml:

    - ghc-exactprint-0.6.3.4@sha256:d17b9ab809e8db9811b13637f1d1d01a82b43e5fe4d72c6d073daadb3f72a921,9446
    - uniplate-1.6.13@sha256:c8b715570d0b4baa72512e677552dd3f98372a64bf9de000e779bd4162fd7be7,3320

    Plan construction failed.

(not using latest LTS (17.4) / ghc-8.10.4 because haskell-language-server binaries are not yet available for it,
and using ghc-8.10.3 for now would be preferable for devs)