### PR TITLE
Make libdir a mandatory parameter to 'applyRefactorings'

### DIFF
--- a/apply-refact.cabal
+++ b/apply-refact.cabal
@@ -36,7 +36,6 @@ library
                , refact >= 0.2
                , ghc-boot-th
                , ghc-exactprint ^>= 1.6.0 || ^>= 1.5.0
-               , ghc-paths
                , containers >= 0.6.0.1 && < 0.7
                , extra >= 1.7.3
                , syb >= 0.7.1

--- a/src/Refact/Apply.hs
+++ b/src/Refact/Apply.hs
@@ -15,6 +15,11 @@ import Refact.Types (Refactoring, SrcSpan)
 
 -- | Apply a set of refactorings as supplied by HLint
 applyRefactorings ::
+  -- | FilePath to [GHC's libdir](https://downloads.haskell.org/ghc/latest/docs/users_guide/using.html#ghc-flag---print-libdir).
+  --
+  -- It is possible to use @libdir@ from [ghc-paths package](https://hackage.haskell.org/package/ghc-paths), but note
+  -- this will make it difficult to provide a binary distribution of your program.
+  FilePath ->
   -- | Apply hints relevant to a specific position
   Maybe (Int, Int) ->
   -- | 'Refactoring's to apply. Each inner list corresponds to an HLint
@@ -35,12 +40,12 @@ applyRefactorings ::
   -- with the @LANGUAGE@ pragmas, pragmas win.
   [String] ->
   IO String
-applyRefactorings optionsPos inp file exts = do
+applyRefactorings libdir optionsPos inp file exts = do
   let (enabled, disabled, invalid) = parseExtensions exts
   unless (null invalid) . fail $ "Unsupported extensions: " ++ intercalate ", " invalid
   m <-
     either (onError "apply") applyFixities
-      =<< parseModuleWithArgs (enabled, disabled) file
+      =<< parseModuleWithArgs libdir (enabled, disabled) file
   apply optionsPos False ((mempty,) <$> inp) (Just file) Silent m
 
 -- | Like 'applyRefactorings', but takes a parsed module rather than a file path to parse.

--- a/src/Refact/Internal.hs
+++ b/src/Refact/Internal.hs
@@ -39,7 +39,6 @@ import Debug.Trace
 import qualified GHC
 import GHC.IO.Exception (IOErrorType (..))
 import GHC.LanguageExtensions.Type (Extension (..))
-import qualified GHC.Paths
 import Language.Haskell.GHC.ExactPrint
   ( ExactPrint,
     exactPrint,
@@ -712,10 +711,11 @@ addExtensionsToFlags es ds fp flags = catchErrors $ do
         . GHC.handleSourceError (pure . Left . show)
 
 parseModuleWithArgs ::
+  LibDir ->
   ([Extension], [Extension]) ->
   FilePath ->
   IO (Either Errors GHC.ParsedSource)
-parseModuleWithArgs (es, ds) fp = ghcWrapper GHC.Paths.libdir $ do
+parseModuleWithArgs libdir (es, ds) fp = ghcWrapper libdir $ do
   initFlags <- initDynFlags fp
   eflags <- liftIO $ addExtensionsToFlags es ds fp initFlags
   case eflags of

--- a/src/Refact/Run.hs
+++ b/src/Refact/Run.hs
@@ -8,6 +8,7 @@ import Data.Maybe
 import Data.Version
 import Debug.Trace
 import Language.Haskell.GHC.ExactPrint.ExactPrint (showAst)
+import qualified GHC.Paths
 import Options.Applicative
 import Paths_apply_refact
 import Refact.Apply (parseExtensions)
@@ -87,7 +88,7 @@ runPipe Options {..} file = do
           "Invalid extensions: " ++ intercalate ", " invalidExts
         m <-
           either (onError "runPipe") applyFixities
-            =<< parseModuleWithArgs (enabledExts, disabledExts) file
+            =<< parseModuleWithArgs GHC.Paths.libdir (enabledExts, disabledExts) file
         when optionsDebug (putStrLn (showAst m))
         apply optionsPos optionsStep inp (Just file) verb m
 


### PR DESCRIPTION
Binary distributions of programs depending on apply-refact are otherwise impossible, since the distributed package will contain a hard-coded path to a libdir to a GHC installation on the host system.

Fixes #133 